### PR TITLE
add_new_book.sh: Update parameter value for skipping reviewers

### DIFF
--- a/_extra/add_new_book.sh
+++ b/_extra/add_new_book.sh
@@ -75,7 +75,7 @@ function create_commit {
 }
 
 function create_pr_and_merge {
-  geet pr create --automated-mode --no-open-pr --reviewers - --labels bookshelf
+  geet pr create --automated-mode --no-open-pr --reviewers '' --labels bookshelf
   geet pr merge
 }
 


### PR DESCRIPTION
Such functionality was not supported, so `-` would not have the desired effect. The functionality is now present in Geet v0.5.0, and the script has been consequently updated.